### PR TITLE
Point benchmarking environment to `ibstore` 0.0.3

### DIFF
--- a/05_benchmark_forcefield/ib-env.yaml
+++ b/05_benchmark_forcefield/ib-env.yaml
@@ -4,6 +4,7 @@ channels:
   - openeye
 dependencies:
   - python
+  - pip
   - click
   - openff-toolkit
   - openff-qcsubmit
@@ -11,3 +12,5 @@ dependencies:
   - openeye-toolkits=2022.1.1
   - openff-interchange-base=0.3.18
   - qcportal=0.15.8
+  - pip:
+    - git+https://github.com/mattwthompson/ib.git@0.0.3


### PR DESCRIPTION
I made this change with https://github.dev/, so any typos are (obviously) not my fault