### PR TITLE
Add ib commit to environment file

### DIFF
--- a/05_benchmark_forcefield/ib-env.yaml
+++ b/05_benchmark_forcefield/ib-env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openmmforcefields
   - openeye-toolkits=2022.1.1
   - openff-interchange-base=0.3.18
-  - qcportal=0.15.8.
+  - qcportal=0.15.8
   - geometric=1
   - pip:
     - git+https://github.com/mattwthompson/ib.git@75d7e5c


### PR DESCRIPTION
FYI, you can add particular git commits to environment files as well -- hopefully that simplifies the installation of environments in 05_benchmark_forcefield :)

Would it also be possible to add `geometric=1` to the file to simplify the environments for benchmarking with internal-coordinates vs other metrics? It looks like that's the only difference between `ib-env` and `ib-env2`.